### PR TITLE
Enum cases to lowercase for Swift 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Transform.swift offers a *Swiftier* API for applying transforms to UIView and its subclasses.
 
 ```swift 
-let scale = Transform.Scale(sx: 0.5, sy: 0.5)
-let rotate = Transform.Rotate(rotation: .Degrees(45))
+let scale = Transform.scale(sx: 0.5, sy: 0.5)
+let rotate = Transform.rotate(rotation: .degrees(45))
 let scaleAndRotate = scale + rotate
 myView.transform += scaleAndRotate
 
-myView.transform3D = .Translate(tx: 40, ty: 0, tz: 100)
+myView.transform3D = .translate(tx: 40, ty: 0, tz: 100)
 ```
 
 <p align="center">
@@ -50,18 +50,18 @@ gitub "jhurray/Transform.swift" ~> 0.1.2
 ###Rotation
 A convenience enum that allows the developer to easily define the rotation they want. The cases are pretty self explanitory.
 
-* `.Degrees(degrees: CGFloat)`
-* `.Radians(radians: Double)`
+* `.degrees(degrees: CGFloat)`
+* `.radians(radians: Double)`
    * Takes a double to make it easier to pass the `M_PI` definitions from `Darwin.C.Math` 
 
 ###Transform
 
-* `.Identity`
-* `.Translate(tx: CGFloat, ty: CGFloat)`
-* `.Scale(sx: CGFloat, sy: CGFloat)`
-* `.Rotate(rotation: Rotation)`
-* `.Init(a: CGFloat, b: CGFloat, c: CGFloat, d: CGFloat, tx: CGFloat, ty: CGFloat)` for the adventurous type 😎
-* `.Custom(t: CGAffineTransform)`
+* `.identity`
+* `.translate(tx: CGFloat, ty: CGFloat)`
+* `.scale(sx: CGFloat, sy: CGFloat)`
+* `.rotate(rotation: Rotation)`
+* `.init(a: CGFloat, b: CGFloat, c: CGFloat, d: CGFloat, tx: CGFloat, ty: CGFloat)` for the adventurous type 😎
+* `.custom(t: CGAffineTransform)`
 
 ####Methods
 
@@ -81,12 +81,12 @@ public var CGATransform: CGAffineTransform { get }
 
 ###Transform3D
 
-* `.Identity`
-* `.Translate(tx: CGFloat, ty: CGFloat, tz: CGFloat)`
-* `.Scale(sx: CGFloat, sy: CGFloat, sz: CGFloat)`
-* `.Rotate(rotation: Rotation, x: CGFloat, y: CGFloat, z: CGFloat)`
-* `.Affine(t: CGAffineTransform)`
-* `.Custom(t: CATransform3D)`
+* `.identity`
+* `.translate(tx: CGFloat, ty: CGFloat, tz: CGFloat)`
+* `.scale(sx: CGFloat, sy: CGFloat, sz: CGFloat)`
+* `.rotate(rotation: Rotation, x: CGFloat, y: CGFloat, z: CGFloat)`
+* `.affine(t: CGAffineTransform)`
+* `.custom(t: CATransform3D)`
 
 ####Methods
 
@@ -96,7 +96,7 @@ Returns the underlying `CATransform3D`
 public var CATransform : CATransform3D { get }
 ```
 
-Returns a `true` if the 3d transform can be converted into an affine transform, `false` if it cannot.
+Returns `true` if the 3d transform can be converted into an affine transform, `false` if it cannot.
 
 ```swift
 public var isAffine: Bool { get }
@@ -112,7 +112,7 @@ public func affineTransform() throws -> CGAffineTransform
 
 * Inverting: `let inverted = t.inverted`
 * Identity Conformation: `let isIdentity = t.isIdentity`
-* Concatenation: `let scaleAndMove = scale.concat(.Translate(tx: 40, ty: -100))`
+* Concatenation: `let scaleAndMove = scale.concat(.translate(tx: 40, ty: -100))`
 
 ###Operators
 
@@ -141,7 +141,7 @@ public func affineTransform() throws -> CGAffineTransform
    * Semantics to assign the transform enum to the old API since you cant overload the `=` operator.
 
 ###UIView Extension
-2 Variables have been added to `UIView` to add settable and gettable interfaces for `Transform` and `Transform3D`.
+Two variables have been added to `UIView` to add settable and gettable interfaces for `Transform` and `Transform3D`.
 
 ```swift
 var affineTransform: Transform

--- a/Transform.playground/Contents.swift
+++ b/Transform.playground/Contents.swift
@@ -7,8 +7,8 @@ import Transform
 let animated = false
 
 let container = UIView()
-container.frame = CGRectMake(0, 0, 400, 400)
-container.backgroundColor = UIColor.greenColor()
+container.frame = CGRect(x: 0, y: 0, width: 400, height: 400)
+container.backgroundColor = .greenColor()
 XCPlaygroundPage.currentPage.liveView = container
 
 let view = UIView()
@@ -17,9 +17,9 @@ view.backgroundColor = .blueColor()
 container.addSubview(view)
 
 let transforms = {
-    view.transform += .Scale(sx: 2.0, sy: 2.0)
-    view.transform += .Translate(tx: 100, ty: 100)
-    view.layer.transform += Transform3D.Rotate(rotation: .Degrees(60), x: 0, y: 1, z: 0)
+    view.transform += .scale(sx: 2.0, sy: 2.0)
+    view.transform += .translate(tx: 100, ty: 100)
+    view.layer.transform += Transform3D.rotate(rotation: .degrees(60), x: 0, y: 1, z: 0)
 }
 
 if animated {

--- a/Transform/Operators.swift
+++ b/Transform/Operators.swift
@@ -48,11 +48,11 @@ public func == (lhs: CATransform3D, rhs: Transform3D) -> Bool {
 // MARK: Additive
 
 public func + (lhs: Transform, rhs: Transform) -> Transform {
-    return Transform.Custom(t: CGAffineTransformConcat(lhs.underlyingTransform(), rhs.underlyingTransform()))
+    return .custom(t: CGAffineTransformConcat(lhs.underlyingTransform(), rhs.underlyingTransform()))
 }
 
 public func + (lhs: Transform3D, rhs: Transform3D) -> Transform3D {
-    return Transform3D.Custom(t: CATransform3DConcat(lhs.underlyingTransform(), rhs.underlyingTransform()))
+    return .custom(t: CATransform3DConcat(lhs.underlyingTransform(), rhs.underlyingTransform()))
 }
 
 public func + (lhs: CGAffineTransform, rhs: CGAffineTransform) -> CGAffineTransform {

--- a/Transform/Rotation.swift
+++ b/Transform/Rotation.swift
@@ -11,15 +11,15 @@ import GLKit.GLKMathUtils
 
 public enum Rotation {
     
-    case Degrees(CGFloat)
+    case degrees(CGFloat)
     // Using Double type to support 𝞹 definitions in Darwin.C.Math
-    case Radians(Double)
+    case radians(Double)
     
-    internal func radians() -> CGFloat {
+    internal var radians: CGFloat {
         switch self {
-        case .Degrees(let degrees):
+        case .degrees(let degrees):
             return CGFloat(GLKMathDegreesToRadians(Float(degrees)))
-        case .Radians(let radians):
+        case .radians(let radians):
             return CGFloat(radians)
         }
     }

--- a/Transform/Transform.swift
+++ b/Transform/Transform.swift
@@ -11,12 +11,12 @@ import CoreGraphics.CGAffineTransform
 
 public enum Transform {
     
-    case Indentity
-    case Translate(tx: CGFloat, ty: CGFloat)
-    case Scale(sx: CGFloat, sy: CGFloat)
-    case Rotate(rotation: Rotation)
-    case Init(a: CGFloat, b: CGFloat, c: CGFloat, d: CGFloat, tx: CGFloat, ty: CGFloat)
-    case Custom(t: CGAffineTransform)
+    case indentity
+    case translate(tx: CGFloat, ty: CGFloat)
+    case scale(sx: CGFloat, sy: CGFloat)
+    case rotate(rotation: Rotation)
+    case `init`(a: CGFloat, b: CGFloat, c: CGFloat, d: CGFloat, tx: CGFloat, ty: CGFloat)
+    case custom(t: CGAffineTransform)
     
     public var CGATransform : CGAffineTransform {
         return self.underlyingTransform()
@@ -27,12 +27,12 @@ public enum Transform {
     }
     
     public var inverted: Transform {
-        return Transform.Custom(t: CGAffineTransformInvert(self.CGATransform))
+        return .custom(t: CGAffineTransformInvert(self.CGATransform))
     }
     
     public mutating func concat(t: Transform) {
         
-        self = Transform.Custom(t: CGAffineTransformConcat(self.CGATransform, t.CGATransform))
+        self = .custom(t: CGAffineTransformConcat(self.CGATransform, t.CGATransform))
     }
     
     public func transformedRect(rect: CGRect) -> CGRect {
@@ -49,17 +49,17 @@ public enum Transform {
     
     internal func underlyingTransform() -> CGAffineTransform {
         switch self {
-        case .Indentity:
+        case .indentity:
             return CGAffineTransformIdentity
-        case .Scale(let sx, let sy):
+        case .scale(let sx, let sy):
             return CGAffineTransformMakeScale(sx, sy)
-        case .Translate(let tx, let ty):
+        case .translate(let tx, let ty):
             return CGAffineTransformMakeTranslation(tx, ty)
-        case .Rotate(let rotation):
-            return CGAffineTransformMakeRotation(rotation.radians())
-        case .Custom(let t):
+        case .rotate(let rotation):
+            return CGAffineTransformMakeRotation(rotation.radians)
+        case .custom(let t):
             return t
-        case .Init(let a, let b, let c, let d, let tx, let ty):
+        case .init(let a, let b, let c, let d, let tx, let ty):
             return CGAffineTransform(a: a, b: b, c: c, d: d, tx: tx, ty: ty)
         }
     }

--- a/Transform/Transform3D.swift
+++ b/Transform/Transform3D.swift
@@ -14,12 +14,12 @@ public enum Transform3DError: ErrorType {
 }
 
 public enum Transform3D {
-    case Indentity
-    case Translate(tx: CGFloat, ty: CGFloat, tz: CGFloat)
-    case Scale(sx: CGFloat, sy: CGFloat, sz: CGFloat)
-    case Rotate(rotation: Rotation, x: CGFloat, y: CGFloat, z: CGFloat)
-    case Affine(t: CGAffineTransform)
-    case Custom(t: CATransform3D)
+    case indentity
+    case translate(tx: CGFloat, ty: CGFloat, tz: CGFloat)
+    case scale(sx: CGFloat, sy: CGFloat, sz: CGFloat)
+    case rotate(rotation: Rotation, x: CGFloat, y: CGFloat, z: CGFloat)
+    case affine(t: CGAffineTransform)
+    case custom(t: CATransform3D)
     
     public var CATransform : CATransform3D {
         return self.underlyingTransform()
@@ -43,26 +43,26 @@ public enum Transform3D {
     }
     
     public var inverted: Transform3D {
-        return Transform3D.Custom(t: CATransform3DInvert(self.CATransform))
+        return .custom(t: CATransform3DInvert(self.CATransform))
     }
     
     public mutating func concat(t: Transform3D) {
-        self = Transform3D.Custom(t: CATransform3DConcat(self.CATransform, t.CATransform))
+        self = .custom(t: CATransform3DConcat(self.CATransform, t.CATransform))
     }
     
     internal func underlyingTransform() -> CATransform3D {
         switch self {
-        case .Indentity:
+        case .indentity:
             return CATransform3DIdentity
-        case .Scale(let sx, let sy, let sz):
+        case .scale(let sx, let sy, let sz):
             return CATransform3DMakeScale(sx, sy, sz)
-        case .Translate(let tx, let ty, let tz):
+        case .translate(let tx, let ty, let tz):
             return CATransform3DMakeTranslation(tx, ty, tz)
-        case .Rotate(let rotation, let x, let y, let z):
-            return CATransform3DMakeRotation(rotation.radians(), x, y, z)
-        case .Custom(let t):
+        case .rotate(let rotation, let x, let y, let z):
+            return CATransform3DMakeRotation(rotation.radians, x, y, z)
+        case .custom(let t):
             return t
-        case .Affine(let t):
+        case .affine(let t):
             return CATransform3DMakeAffineTransform(t)
         }
     }

--- a/Transform/UIView+Transform3D.swift
+++ b/Transform/UIView+Transform3D.swift
@@ -15,7 +15,7 @@ extension UIView {
     
     public var affineTransform: Transform {
         get {
-            return Transform.Custom(t: self.transform)
+            return .custom(t: self.transform)
         }
         set {
             self.transform = newValue.underlyingTransform()
@@ -24,7 +24,7 @@ extension UIView {
     
     public var transform3D: Transform3D {
         get {
-            return Transform3D.Custom(t: self.layer.transform)
+            return .custom(t: self.layer.transform)
         }
         set {
             self.layer.transform = newValue.underlyingTransform()


### PR DESCRIPTION
Hey, I just setup the lowercased enum cases to help with the conversion of the library once Swift 3 comes around. :-)
